### PR TITLE
[OPENENGSB-3257] downgraded axis2 java2wsdl maven plugin to version 1.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
         <plugin>
           <groupId>org.apache.axis2</groupId>
           <artifactId>axis2-java2wsdl-maven-plugin</artifactId>
-          <version>1.6.2</version>
+          <version>1.6.1</version>
         </plugin>
         <plugin>
           <groupId>org.openengsb</groupId>


### PR DESCRIPTION
need to be downgraded that the changes for pull request https://github.com/openengsb/openengsb-framework/pull/746 work and no NullPointerException happens when the EDB API WSDL is generated

http://issues.openengsb.org/jira/browse/OPENENGSB-3257
